### PR TITLE
fix: terraform-dir might be different for complex modules

### DIFF
--- a/.github/workflows/terraform-module-validation.yml
+++ b/.github/workflows/terraform-module-validation.yml
@@ -60,6 +60,12 @@ on:
         required: false
         type: string
 
+      terraform-tests-dir:
+        default: "."
+        description: "The terraform test directory"
+        required: false
+        type: string
+
       terraform-version:
         default: "1.7.1"
         description: "The version of terraform to use"
@@ -178,10 +184,10 @@ jobs:
           role-to-assume: ${{ inputs.terraform-tests-aws-role }}
           mask-aws-account-id: "no"
       - name: Terraform Init
-        run: terraform -chdir=${{ inputs.terraform-dir }} init -backend=false
+        run: terraform -chdir=${{ inputs.terraform-tests-dir }} init -backend=false
       - name: Run Tests
         id: tests
-        run: terraform -chdir=${{ inputs.terraform-dir }} test
+        run: terraform -chdir=${{ inputs.terraform-tests-dir }} test
 
   terraform-init:
     name: "Terraform Init"


### PR DESCRIPTION
`terraform validate` may fail if ran against a complex reusable module with multiple providers e.g., [appvia/terraform-aws-cloudaccess-lza](https://github.com/appvia/terraform-aws-cloudaccess-lza/pull/25) because it requires explicit provider configurations to be declared in the terraform configuration. 

However, that's not a good practice and it is recommendation that `terraform validate` is ran against a root module (one that sources the reusable module) with provider configurations instead.

On the other hand, `terraform test` is unable to discover test files even if you specify `-filter` and target a specific file or specify `-test-directory` and target the `tests` directory. 

Therefore, the best solution to support both cases would be to support an additional variable that enables us to specify a different terraform test directory using the terraform global flag `-chdir`. 

References:
- https://github.com/hashicorp/terraform/issues/31306#issuecomment-1164486293
- https://github.com/hashicorp/terraform/issues/33582