### PR TITLE
chore: change this to string

### DIFF
--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -22,7 +22,7 @@ on:
       aws-account-id:
         description: "The AWS account ID to deploy to"
         required: true
-        type: number
+        type: string
 
       aws-role:
         default: "${{ github.event.repository.name }}"


### PR DESCRIPTION
reason:

This results in '012140491173' being treated as '12140491173', causing the mismatch in the AWS role ARN.