### PR TITLE
feat: ci-cd-workflow - Allow passing of terraform options to init, plan, apply and destroy

### DIFF
--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -96,9 +96,21 @@ on:
         required: false
         type: string
 
+      terraform-apply-extra-args:
+        default: ""
+        description: "Extra arguments to pass to terraform apply"
+        required: false
+        type: string
+
       terraform-dir:
         default: "."
         description: "The directory to validate"
+        required: false
+        type: string
+
+      terraform-init-extra-args:
+        default: ""
+        description: "Extra arguments to pass to terraform init"
         required: false
         type: string
 
@@ -111,6 +123,12 @@ on:
       terraform-log-level:
         default: ""
         description: "The log level of terraform"
+        required: false
+        type: string
+
+      terraform-plan-extra-args:
+        default: ""
+        description: "Extra arguments to pass to terraform plan"
         required: false
         type: string
 
@@ -226,7 +244,14 @@ jobs:
           git config --global url."https://x-access-token:${{steps.get_workflow_token.outputs.token}}@github.com/".insteadOf "https://github.com/"
       - name: Terraform Init
         id: init
-        run: terraform -chdir=${{ inputs.terraform-dir }} init -backend-config="bucket=${{ inputs.aws-account-id }}-${{ inputs.aws-region }}-tfstate" -backend-config="key=${{ steps.state-key.outputs.name }}" -backend-config="encrypt=true" -backend-config="dynamodb_table=${{ inputs.aws-account-id }}-${{ inputs.aws-region }}-tflock" -backend-config="region=${{ inputs.aws-region }}"
+        run: |
+          terraform -chdir=${{ inputs.terraform-dir }} init \
+          -backend-config="bucket=${{ inputs.aws-account-id }}-${{ inputs.aws-region }}-tfstate" \
+          -backend-config="key=${{ steps.state-key.outputs.name }}" \
+          -backend-config="encrypt=true" \
+          -backend-config="dynamodb_table=${{ inputs.aws-account-id }}-${{ inputs.aws-region }}-tflock" \
+          -backend-config="region=${{ inputs.aws-region }}" \
+          ${{ inputs.terraform-init-extra-args }}
       - name: Terraform Validate
         id: validate
         run: terraform -chdir=${{ inputs.terraform-dir }} validate -no-color
@@ -250,7 +275,14 @@ jobs:
         id: plan
         run: |
           set -o pipefail
-          terraform -chdir=${{ inputs.terraform-dir }} plan -destroy -var-file="${TF_VAR_FILE}" -no-color -input=false -out=tfplan -lock-timeout=${{ inputs.terraform-lock-timeout }} 2>&1 | tee tfplan.stdout
+          terraform -chdir=${{ inputs.terraform-dir }} plan \
+          -destroy -var-file="${TF_VAR_FILE}" \
+          -no-color \
+          -input=false \
+          -out=tfplan \
+          -lock-timeout=${{ inputs.terraform-lock-timeout }} \
+          ${{ inputs.terraform-plan-extra-args }} \
+          2>&1 | tee tfplan.stdout
       - name: Terraform Plan JSON Output
         run: |
           terraform -chdir=${{ inputs.terraform-dir }} show -json tfplan > tfplan.json
@@ -340,7 +372,14 @@ jobs:
           git config --global url."https://x-access-token:${{steps.get_workflow_token.outputs.token}}@github.com/".insteadOf "https://github.com/"
       - name: Terraform Init
         id: init
-        run: terraform -chdir=${{ inputs.terraform-dir }} init -backend-config="bucket=${{ inputs.aws-account-id }}-${{ inputs.aws-region }}-tfstate" -backend-config="key=${{ steps.state-key.outputs.name }}" -backend-config="encrypt=true" -backend-config="dynamodb_table=${{ inputs.aws-account-id }}-${{ inputs.aws-region }}-tflock" -backend-config="region=${{ inputs.aws-region }}"
+        run: |
+          terraform -chdir=${{ inputs.terraform-dir }} init \
+          -backend-config="bucket=${{ inputs.aws-account-id }}-${{ inputs.aws-region }}-tfstate" \
+          -backend-config="key=${{ steps.state-key.outputs.name }}" \
+          -backend-config="encrypt=true" \
+          -backend-config="dynamodb_table=${{ inputs.aws-account-id }}-${{ inputs.aws-region }}-tflock" \
+          -backend-config="region=${{ inputs.aws-region }}" \
+          ${{ inputs.terraform-init-extra-args }}
       - name: Download tfplan
         uses: actions/download-artifact@v4
         with:
@@ -352,4 +391,8 @@ jobs:
           name: additional-dir-${{ inputs.environment }}
           path: ${{ inputs.additional-dir }}
       - name: Terraform Apply
-        run: terraform apply -auto-approve -input=false -lock-timeout=${{ inputs.terraform-lock-timeout }} tfplan
+        run: |
+          terraform apply -auto-approve -input=false \
+          -lock-timeout=${{ inputs.terraform-lock-timeout }} \
+          ${{ inputs.terraform-apply-extra-args }} \
+          tfplan

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -112,9 +112,21 @@ on:
         required: false
         type: string
 
+      terraform-apply-extra-args:
+        default: ""
+        description: "Extra arguments to pass to terraform apply"
+        required: false
+        type: string
+
       terraform-dir:
         default: "."
         description: "The directory to validate"
+        required: false
+        type: string
+
+      terraform-init-extra-args:
+        default: ""
+        description: "Extra arguments to pass to terraform init"
         required: false
         type: string
 
@@ -127,6 +139,12 @@ on:
       terraform-log-level:
         default: ""
         description: "The log level of terraform"
+        required: false
+        type: string
+
+      terraform-plan-extra-args:
+        default: ""
+        description: "Extra arguments to pass to terraform plan"
         required: false
         type: string
 
@@ -177,7 +195,6 @@ env:
   AWS_READONLY_OVERRIDE_ROLE: ${{ inputs.aws-read-role-name }}
   AWS_READWRITE_OVERRIDE_ROLE: ${{ inputs.aws-write-role-name }}
   AWS_WEB_IDENTITY_TOKEN_FILE: /tmp/web_identity_token_file
-  TF_LOG: ${{ inputs.terraform-log-level }}
 
 permissions:
   id-token: write
@@ -185,6 +202,25 @@ permissions:
   pull-requests: write
 
 jobs:
+  debug-mode:
+    name: "Debug Mode"
+    runs-on: ubuntu-latest
+    outputs:
+      tf_log: ${{ steps.debug.outputs.tf_log }}
+    steps:
+      - name: Debug Mode Vars
+        id: debug
+        run: |
+          if "${{ runner.debug == true }}"; then
+            if [ "${{ inputs.terraform-log-level }}" == "TRACE" ]; then
+              echo "tf_log=TRACE" >> $GITHUB_ENV
+            else
+              echo "tf_log=DEBUG" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "tf_log=${{ inputs.terraform-log-level }}" >> $GITHUB_OUTPUT
+          fi
+
   commitlint:
     name: "Commitlint"
     if: github.event_name == 'pull_request' && inputs.enable-commitlint
@@ -263,7 +299,7 @@ jobs:
         with:
           terraform_version: ${{ inputs.terraform-version }}
       - name: Terraform Init
-        run: terraform -chdir=${{ inputs.terraform-dir }} init -backend=false
+        run: terraform -chdir=${{ inputs.terraform-dir }} init -backend=false ${{ inputs.terraform-init-extra-args }}
       - name: Setup Linter
         uses: terraform-linters/setup-tflint@v4
       - name: Linter Initialize
@@ -327,12 +363,16 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
+    needs:
+      - debug-mode
     outputs:
       result-auth: ${{ steps.auth.outcome }}
       result-init: ${{ steps.init.outcome }}
       result-validate: ${{ steps.validate.outcome }}
       result-s3-backend-check: ${{ steps.s3-backend-check.outcome }}
       result-plan: ${{ steps.plan.outcome }}
+    env:
+      TF_LOG: ${{ needs.debug-mode.outputs.tf_log }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -424,7 +464,9 @@ jobs:
             -no-color -input=false \
             -out=tfplan \
             -parallelism=${{ inputs.terraform-parallelism }} \
-            -lock-timeout=${{ inputs.terraform-lock-timeout }} 2>&1 | tee tfplan.stdout
+            -lock-timeout=${{ inputs.terraform-lock-timeout }} \
+            ${{ inputs.terraform-plan-extra-args }} \
+            2>&1 | tee tfplan.stdout
       - name: Terraform Plan JSON Output
         run: |
           terraform -chdir=${{ inputs.terraform-dir }} show -json tfplan > tfplan.json
@@ -676,10 +718,13 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
+    env:
+      TF_LOG: ${{ needs.debug-mode.outputs.tf_log }}
     needs:
       - terraform-format
       - terraform-lint
       - terraform-plan
+      - debug-mode
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -753,4 +798,6 @@ jobs:
             -auto-approve \
             -input=false \
             -parallelism=${{ inputs.terraform-parallelism }} \
-            -lock-timeout=${{ inputs.terraform-lock-timeout }} tfplan
+            -lock-timeout=${{ inputs.terraform-lock-timeout }} \
+            ${{ inputs.terraform-apply-extra-args }} \
+            tfplan


### PR DESCRIPTION
https://appvia.atlassian.net/jira/software/c/projects/SA/boards/11?selectedIssue=SA-309

This PR is twofold:

1) To enable terraform debug logging on a rerun, you can enable runner debugging (clicking re-run and ticking the "enable debug mode" button). This will always set the TF_LOG value to DEBUG, _unless_ manually, the user has set the TG_LOG mode to TRACE as TRACE is a more verbose level of logging than DEBUG.

The newly introduced `debug-mode` job is used to calculate the intended value of TF_LOG depending on inputs/runner debug mode. The reason this can't be done as part of the template language logic in the workflow global env var declaration is because github actions only makes the `runner` context available within a job.

2) Enable passing of custom args to the TF cmds:
- terraform-init-extra-args
- terraform-plan-extra-args
- terraform-apply-extra-args

These accept a string which gets appended to the last arg already included/required by the workflow.