### PR TITLE
feat: support terraform github provider

### DIFF
--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -420,6 +420,7 @@ jobs:
             echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id}}" >> "${GITUB_ENV}"
             echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITUB_ENV}"
             echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key}}'" >> "${GITHUB_ENV}"
+          fi
       - name: Terraform Plan
         id: plan
         run: |
@@ -738,9 +739,9 @@ jobs:
       - name: Add GitHub provider credentials to environment
         run: |
           if [ -n "${{ secrets.github-provider-app-id }}" && -n "${{ secrets.github-provider-installation-id }}" && -n "${{ secrets.github-provider-private-key}}" ]; then
-            echo "GITHUB_PROVIDER_APP_ID=${{ secrets.github-provider-app-id}}" >> "${GITUB_ENV}"
-            echo "GITHUB_PROVIDER_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITUB_ENV}"
-            echo "GITHUB_PROVIDER_PRIVATE_KEY='${{ secrets.github-provider-private-key}}'" >> "${GITHUB_ENV}"
+            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id}}" >> "${GITUB_ENV}"
+            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITUB_ENV}"
+            echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key}}'" >> "${GITHUB_ENV}"
           fi
       - name: Terraform Apply
         run: |

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -417,8 +417,8 @@ jobs:
       - name: Add GitHub provider credentials to environment
         run: |
           if [ -n "${{ secrets.github-provider-app-id }}" ] && [ -n "${{ secrets.github-provider-installation-id }}" ] && [ -n "${{ secrets.github-provider-private-key}}" ]; then
-            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id}}" >> "${GITUB_ENV}"
-            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITUB_ENV}"
+            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id}}" >> "${GITHUB_ENV}"
+            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITHUB_ENV}"
             echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key}}'" >> "${GITHUB_ENV}"
           fi
       - name: Terraform Plan
@@ -740,7 +740,7 @@ jobs:
         run: |
           if [ -n "${{ secrets.github-provider-app-id }}" ] && [ -n "${{ secrets.github-provider-installation-id }}" ] && [ -n "${{ secrets.github-provider-private-key}}" ]; then
             echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id}}" >> "${GITUB_ENV}"
-            echo "GITHUB_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITUB_ENV}"
+            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITUB_ENV}"
             echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key}}'" >> "${GITHUB_ENV}"
           fi
       - name: Terraform Apply

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -12,6 +12,15 @@ on:
       appvia-actions-secret:
         description: "Appvia App secret for GH"
         required: false
+      github-provider-app-id:
+        description: "GitHub provider app ID"
+        required: false
+      github-provider-installation-id:
+        description: "GitHub provider installation ID"
+        required: false
+      github-provider-private-key:
+        description: "Private key for GitHub provider app"
+        required: false
 
     inputs:
       additional-dir:
@@ -405,6 +414,12 @@ jobs:
           else
             echo "TF_VAR_FILE=values/${{ inputs.environment }}.tfvars" >> "${GITHUB_ENV}"
           fi
+      - name: Add GitHub provider credentials to environment
+        run: |
+          if [ -n "${{ secrets.github-provider-app-id }}" && -n "${{ secrets.github-provider-installation-id }}" && -n "${{ secrets.github-provider-private-key}}" ]; then
+            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id}}" >> "${GITUB_ENV}"
+            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITUB_ENV}"
+            echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key}}'" >> "${GITHUB_ENV}"
       - name: Terraform Plan
         id: plan
         run: |
@@ -719,6 +734,13 @@ jobs:
             echo "Checksum validation failed. The tfplan artifact has been modified or tampered with since the plan was generated."
             echo "Halting Terraform Apply phase to ensure the integrity of the deployment process."
             exit 1
+          fi
+      - name: Add GitHub provider credentials to environment
+        run: |
+          if [ -n "${{ secrets.github-provider-app-id }}" && -n "${{ secrets.github-provider-installation-id }}" && -n "${{ secrets.github-provider-private-key}}" ]; then
+            echo "GITHUB_PROVIDER_APP_ID=${{ secrets.github-provider-app-id}}" >> "${GITUB_ENV}"
+            echo "GITHUB_PROVIDER_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITUB_ENV}"
+            echo "GITHUB_PROVIDER_PRIVATE_KEY='${{ secrets.github-provider-private-key}}'" >> "${GITHUB_ENV}"
           fi
       - name: Terraform Apply
         run: |

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -417,9 +417,11 @@ jobs:
       - name: Add GitHub provider credentials to environment
         run: |
           if [ -n "${{ secrets.github-provider-app-id }}" ] && [ -n "${{ secrets.github-provider-installation-id }}" ] && [ -n "${{ secrets.github-provider-private-key}}" ]; then
-            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id}}" >> "${GITHUB_ENV}"
-            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITHUB_ENV}"
-            echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key}}'" >> "${GITHUB_ENV}"
+            {
+            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id }}"
+            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id }}"
+            echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key }}'"
+            } >> "${GITHUB_ENV}"
           fi
       - name: Terraform Plan
         id: plan
@@ -739,9 +741,11 @@ jobs:
       - name: Add GitHub provider credentials to environment
         run: |
           if [ -n "${{ secrets.github-provider-app-id }}" ] && [ -n "${{ secrets.github-provider-installation-id }}" ] && [ -n "${{ secrets.github-provider-private-key}}" ]; then
-            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id}}" >> "${GITUB_ENV}"
-            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITUB_ENV}"
-            echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key}}'" >> "${GITHUB_ENV}"
+            {
+            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id }}"
+            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id }}"
+            echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key }}'"
+            } >> "${GITHUB_ENV}"
           fi
       - name: Terraform Apply
         run: |

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -416,7 +416,7 @@ jobs:
           fi
       - name: Add GitHub provider credentials to environment
         run: |
-          if [ -n "${{ secrets.github-provider-app-id }}" && -n "${{ secrets.github-provider-installation-id }}" && -n "${{ secrets.github-provider-private-key}}" ]; then
+          if [ -n "${{ secrets.github-provider-app-id }}" ] && [ -n "${{ secrets.github-provider-installation-id }}" ] && [ -n "${{ secrets.github-provider-private-key}}" ]; then
             echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id}}" >> "${GITUB_ENV}"
             echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITUB_ENV}"
             echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key}}'" >> "${GITHUB_ENV}"
@@ -738,9 +738,9 @@ jobs:
           fi
       - name: Add GitHub provider credentials to environment
         run: |
-          if [ -n "${{ secrets.github-provider-app-id }}" && -n "${{ secrets.github-provider-installation-id }}" && -n "${{ secrets.github-provider-private-key}}" ]; then
+          if [ -n "${{ secrets.github-provider-app-id }}" ] && [ -n "${{ secrets.github-provider-installation-id }}" ] && [ -n "${{ secrets.github-provider-private-key}}" ]; then
             echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id}}" >> "${GITUB_ENV}"
-            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITUB_ENV}"
+            echo "GITHUB_INSTALLATION_ID=${{ secrets.github-provider-installation-id}}" >> "${GITUB_ENV}"
             echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key}}'" >> "${GITHUB_ENV}"
           fi
       - name: Terraform Apply

--- a/docs/terraform-plan-and-apply-aws.md
+++ b/docs/terraform-plan-and-apply-aws.md
@@ -19,6 +19,8 @@ This GitHub Actions workflow template ([terraform-plan-and-apply-aws.yml](../.gi
 
 ## Usage
 
+**Note:** This template may change over time, so it is recommended that you point to a tagged version rather than the main branch.
+
 Create a new workflow file in your Terraform repository (e.g. `.github/workflows/terraform.yml`) with the below contents:
 
 ```yml
@@ -42,7 +44,22 @@ jobs:
       aws-role: <IAM_ROLE_NAME>
       enable-infracost: true
 ```
-
 The `aws-role` inputs are optional and will default to the repository name.
 
-**Note:** This template may change over time, so it is recommended that you point to a tagged version rather than the main branch.
+### GitHub provider support
+
+The Terraform GitHub provider requires a GitHub App to be configured in GitHub with the permissions necessary depending on the resources used. The workflow supports the following secrets to configure the provider:
+
+- `github_provider_app_id` - The GitHub App ID to be used by the provider.
+- `github_provider_installation_id` - The GitHub App installation ID.
+- `github_provider_private_key` - The generated private key for the provider GitHub App.
+
+These secrets are then automatically made available to the provider through environment variables, example provider configuration:
+
+```
+provider "github" {
+  owner = "my-organisation"
+  app_auth {}
+}
+```
+


### PR DESCRIPTION
This PR adds the ability to pass GitHub App credentials to the plan and apply workflow to be consumed by the [GitHub provider](https://github.com/integrations/terraform-provider-github). The provider consumes an app ID, installation ID and a private key to authenticate. Support has been added by allowing the following additional secrets to be specified to the workflow:

- `github-provider-app-id`
- `github-provider-installation-id`
- `github-provider-private-key`

If specified, the secrets are passed through to the GitHub provider in the terraform plan and apply stages through environment variables. The provider will automatically consume the variables when no other credentials are provided:

```
provider "github" {
  owner = "my-organisation"
  app_auth {}
}
```