### PR TITLE
Revert "feat: support terraform github provider"

### DIFF
--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -12,15 +12,6 @@ on:
       appvia-actions-secret:
         description: "Appvia App secret for GH"
         required: false
-      github-provider-app-id:
-        description: "GitHub provider app ID"
-        required: false
-      github-provider-installation-id:
-        description: "GitHub provider installation ID"
-        required: false
-      github-provider-private-key:
-        description: "Private key for GitHub provider app"
-        required: false
 
     inputs:
       additional-dir:
@@ -414,15 +405,6 @@ jobs:
           else
             echo "TF_VAR_FILE=values/${{ inputs.environment }}.tfvars" >> "${GITHUB_ENV}"
           fi
-      - name: Add GitHub provider credentials to environment
-        run: |
-          if [ -n "${{ secrets.github-provider-app-id }}" ] && [ -n "${{ secrets.github-provider-installation-id }}" ] && [ -n "${{ secrets.github-provider-private-key}}" ]; then
-            {
-            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id }}"
-            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id }}"
-            echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key }}'"
-            } >> "${GITHUB_ENV}"
-          fi
       - name: Terraform Plan
         id: plan
         run: |
@@ -737,15 +719,6 @@ jobs:
             echo "Checksum validation failed. The tfplan artifact has been modified or tampered with since the plan was generated."
             echo "Halting Terraform Apply phase to ensure the integrity of the deployment process."
             exit 1
-          fi
-      - name: Add GitHub provider credentials to environment
-        run: |
-          if [ -n "${{ secrets.github-provider-app-id }}" ] && [ -n "${{ secrets.github-provider-installation-id }}" ] && [ -n "${{ secrets.github-provider-private-key}}" ]; then
-            {
-            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id }}"
-            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id }}"
-            echo "GITHUB_APP_PEM_FILE='${{ secrets.github-provider-private-key }}'"
-            } >> "${GITHUB_ENV}"
           fi
       - name: Terraform Apply
         run: |

--- a/docs/terraform-plan-and-apply-aws.md
+++ b/docs/terraform-plan-and-apply-aws.md
@@ -19,8 +19,6 @@ This GitHub Actions workflow template ([terraform-plan-and-apply-aws.yml](../.gi
 
 ## Usage
 
-**Note:** This template may change over time, so it is recommended that you point to a tagged version rather than the main branch.
-
 Create a new workflow file in your Terraform repository (e.g. `.github/workflows/terraform.yml`) with the below contents:
 
 ```yml
@@ -44,22 +42,7 @@ jobs:
       aws-role: <IAM_ROLE_NAME>
       enable-infracost: true
 ```
+
 The `aws-role` inputs are optional and will default to the repository name.
 
-### GitHub provider support
-
-The Terraform GitHub provider requires a GitHub App to be configured in GitHub with the permissions necessary depending on the resources used. The workflow supports the following secrets to configure the provider:
-
-- `github_provider_app_id` - The GitHub App ID to be used by the provider.
-- `github_provider_installation_id` - The GitHub App installation ID.
-- `github_provider_private_key` - The generated private key for the provider GitHub App.
-
-These secrets are then automatically made available to the provider through environment variables, example provider configuration:
-
-```
-provider "github" {
-  owner = "my-organisation"
-  app_auth {}
-}
-```
-
+**Note:** This template may change over time, so it is recommended that you point to a tagged version rather than the main branch.


### PR DESCRIPTION
Reverts appvia/appvia-cicd-workflows#65

Further testing has shown the secret masking results in a broken configuration: https://github.com/appvia-lz-aws/gh-provisioning/actions/runs/16028490082/job/45222585184