### PR TITLE
feat: add GitHub provider support with base64 encoded private keys

### DIFF
--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -422,6 +422,8 @@ jobs:
             # Decode base64 encoded private key and write to file
             echo "${{ secrets.gh-provider-private-key }}" | base64 -d > /tmp/github-app-private-key.pem
             echo "GITHUB_APP_PEM_FILE=/tmp/github-app-private-key.pem" >> "${GITHUB_ENV}"
+          else
+            echo "GitHub provider credentials not provided."
           fi
       - name: Terraform Plan
         id: plan

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -12,6 +12,15 @@ on:
       appvia-actions-secret:
         description: "Appvia App secret for GH"
         required: false
+      github-provider-app-id:
+        description: "GitHub provider app ID"
+        required: false
+      github-provider-installation-id:
+        description: "GitHub provider installation ID"
+        required: false
+      github-provider-private-key:
+        description: "Base64 encoded private key for GitHub provider app"
+        required: false
 
     inputs:
       additional-dir:
@@ -405,6 +414,15 @@ jobs:
           else
             echo "TF_VAR_FILE=values/${{ inputs.environment }}.tfvars" >> "${GITHUB_ENV}"
           fi
+      - name: Add GitHub provider credentials to environment
+        run: |
+          if [ -n "${{ secrets.github-provider-app-id }}" ] && [ -n "${{ secrets.github-provider-installation-id }}" ] && [ -n "${{ secrets.github-provider-private-key }}" ]; then
+            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id }}" >> "${GITHUB_ENV}"
+            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id }}" >> "${GITHUB_ENV}"
+            # Decode base64 encoded private key and write to file
+            echo "${{ secrets.github-provider-private-key }}" | base64 -d > /tmp/github-app-private-key.pem
+            echo "GITHUB_APP_PEM_FILE=/tmp/github-app-private-key.pem" >> "${GITHUB_ENV}"
+          fi
       - name: Terraform Plan
         id: plan
         run: |
@@ -719,6 +737,15 @@ jobs:
             echo "Checksum validation failed. The tfplan artifact has been modified or tampered with since the plan was generated."
             echo "Halting Terraform Apply phase to ensure the integrity of the deployment process."
             exit 1
+          fi
+      - name: Add GitHub provider credentials to environment
+        run: |
+          if [ -n "${{ secrets.github-provider-app-id }}" ] && [ -n "${{ secrets.github-provider-installation-id }}" ] && [ -n "${{ secrets.github-provider-private-key }}" ]; then
+            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id }}" >> "${GITHUB_ENV}"
+            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id }}" >> "${GITHUB_ENV}"
+            # Decode base64 encoded private key and write to file
+            echo "${{ secrets.github-provider-private-key }}" | base64 -d > /tmp/github-app-private-key.pem
+            echo "GITHUB_APP_PEM_FILE=/tmp/github-app-private-key.pem" >> "${GITHUB_ENV}"
           fi
       - name: Terraform Apply
         run: |

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -420,8 +420,8 @@ jobs:
             echo "GITHUB_APP_ID=${{ secrets.gh-provider-app-id }}" >> "${GITHUB_ENV}"
             echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.gh-provider-installation-id }}" >> "${GITHUB_ENV}"
             # Decode base64 encoded private key and write to file
-            echo "${{ secrets.gh-provider-private-key }}" | base64 -d > /tmp/github-app-private-key.pem
-            echo "GITHUB_APP_PEM_FILE=/tmp/github-app-private-key.pem" >> "${GITHUB_ENV}"
+            echo "${{ secrets.gh-provider-private-key }}" | base64 -d > ${RUNNER_TEMP}/github-app-private-key.pem
+            echo "GITHUB_APP_PEM_FILE=${RUNNER_TEMP}/github-app-private-key.pem" >> "${GITHUB_ENV}"
           else
             echo "GitHub provider credentials not provided."
           fi
@@ -746,8 +746,8 @@ jobs:
             echo "GITHUB_APP_ID=${{ secrets.gh-provider-app-id }}" >> "${GITHUB_ENV}"
             echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.gh-provider-installation-id }}" >> "${GITHUB_ENV}"
             # Decode base64 encoded private key and write to file
-            echo "${{ secrets.gh-provider-private-key }}" | base64 -d > /tmp/github-app-private-key.pem
-            echo "GITHUB_APP_PEM_FILE=/tmp/github-app-private-key.pem" >> "${GITHUB_ENV}"
+            echo "${{ secrets.gh-provider-private-key }}" | base64 -d > ${RUNNER_TEMP}/github-app-private-key.pem
+            echo "GITHUB_APP_PEM_FILE=${RUNNER_TEMP}/github-app-private-key.pem" >> "${GITHUB_ENV}"
           fi
       - name: Terraform Apply
         run: |

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -12,13 +12,13 @@ on:
       appvia-actions-secret:
         description: "Appvia App secret for GH"
         required: false
-      github-provider-app-id:
+      gh-provider-app-id:
         description: "GitHub provider app ID"
         required: false
-      github-provider-installation-id:
+      gh-provider-installation-id:
         description: "GitHub provider installation ID"
         required: false
-      github-provider-private-key:
+      gh-provider-private-key:
         description: "Base64 encoded private key for GitHub provider app"
         required: false
 
@@ -416,11 +416,11 @@ jobs:
           fi
       - name: Add GitHub provider credentials to environment
         run: |
-          if [ -n "${{ secrets.github-provider-app-id }}" ] && [ -n "${{ secrets.github-provider-installation-id }}" ] && [ -n "${{ secrets.github-provider-private-key }}" ]; then
-            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id }}" >> "${GITHUB_ENV}"
-            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id }}" >> "${GITHUB_ENV}"
+          if [ -n "${{ secrets.gh-provider-app-id }}" ] && [ -n "${{ secrets.gh-provider-installation-id }}" ] && [ -n "${{ secrets.gh-provider-private-key }}" ]; then
+            echo "GITHUB_APP_ID=${{ secrets.gh-provider-app-id }}" >> "${GITHUB_ENV}"
+            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.gh-provider-installation-id }}" >> "${GITHUB_ENV}"
             # Decode base64 encoded private key and write to file
-            echo "${{ secrets.github-provider-private-key }}" | base64 -d > /tmp/github-app-private-key.pem
+            echo "${{ secrets.gh-provider-private-key }}" | base64 -d > /tmp/github-app-private-key.pem
             echo "GITHUB_APP_PEM_FILE=/tmp/github-app-private-key.pem" >> "${GITHUB_ENV}"
           fi
       - name: Terraform Plan
@@ -740,11 +740,11 @@ jobs:
           fi
       - name: Add GitHub provider credentials to environment
         run: |
-          if [ -n "${{ secrets.github-provider-app-id }}" ] && [ -n "${{ secrets.github-provider-installation-id }}" ] && [ -n "${{ secrets.github-provider-private-key }}" ]; then
-            echo "GITHUB_APP_ID=${{ secrets.github-provider-app-id }}" >> "${GITHUB_ENV}"
-            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.github-provider-installation-id }}" >> "${GITHUB_ENV}"
+          if [ -n "${{ secrets.gh-provider-app-id }}" ] && [ -n "${{ secrets.gh-provider-installation-id }}" ] && [ -n "${{ secrets.gh-provider-private-key }}" ]; then
+            echo "GITHUB_APP_ID=${{ secrets.gh-provider-app-id }}" >> "${GITHUB_ENV}"
+            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.gh-provider-installation-id }}" >> "${GITHUB_ENV}"
             # Decode base64 encoded private key and write to file
-            echo "${{ secrets.github-provider-private-key }}" | base64 -d > /tmp/github-app-private-key.pem
+            echo "${{ secrets.gh-provider-private-key }}" | base64 -d > /tmp/github-app-private-key.pem
             echo "GITHUB_APP_PEM_FILE=/tmp/github-app-private-key.pem" >> "${GITHUB_ENV}"
           fi
       - name: Terraform Apply

--- a/docs/terraform-plan-and-apply-aws.md
+++ b/docs/terraform-plan-and-apply-aws.md
@@ -65,9 +65,9 @@ The workflow supports the Terraform GitHub provider through GitHub App authentic
    base64 github-app-private-key.pem > github-app-private-key-base64.txt
    ```
 4. Store the following as GitHub secrets in your repository:
-   - `GITHUB_PROVIDER_APP_ID` - The GitHub App ID
-   - `GITHUB_PROVIDER_INSTALLATION_ID` - The GitHub App installation ID
-   - `GITHUB_PROVIDER_PRIVATE_KEY` - The base64 encoded private key from step 3
+   - `GH_PROVIDER_APP_ID` - The GitHub App ID
+   - `GH_PROVIDER_INSTALLATION_ID` - The GitHub App installation ID
+   - `GH_PROVIDER_PRIVATE_KEY` - The base64 encoded private key from step 3
 
 5. Pass these secrets to the workflow:
    ```yml
@@ -76,9 +76,9 @@ The workflow supports the Terraform GitHub provider through GitHub App authentic
        uses: appvia/appvia-cicd-workflows/.github/workflows/terraform-plan-and-apply-aws.yml@main
        name: Plan and Apply
        secrets:
-         github-provider-app-id: ${{ secrets.GITHUB_PROVIDER_APP_ID }}
-         github-provider-installation-id: ${{ secrets.GITHUB_PROVIDER_INSTALLATION_ID }}
-         github-provider-private-key: ${{ secrets.GITHUB_PROVIDER_PRIVATE_KEY }}
+         gh-provider-app-id: ${{ secrets.GH_PROVIDER_APP_ID }}
+         gh-provider-installation-id: ${{ secrets.GH_PROVIDER_INSTALLATION_ID }}
+         gh-provider-private-key: ${{ secrets.GH_PROVIDER_PRIVATE_KEY }}
        with:
          aws-account: 123456789012
          # ... other inputs

--- a/docs/terraform-plan-and-apply-aws.md
+++ b/docs/terraform-plan-and-apply-aws.md
@@ -46,3 +46,50 @@ jobs:
 The `aws-role` inputs are optional and will default to the repository name.
 
 **Note:** This template may change over time, so it is recommended that you point to a tagged version rather than the main branch.
+
+### GitHub Provider Support
+
+The workflow supports the Terraform GitHub provider through GitHub App authentication. To use this feature, you need to:
+
+1. Create a GitHub App with the necessary permissions for your Terraform resources
+2. Generate a private key for the GitHub App
+3. Base64 encode the private key file:
+   ```bash
+   # macOS
+   base64 -i github-app-private-key.pem | pbcopy
+   
+   # Linux
+   base64 github-app-private-key.pem | xclip -selection clipboard
+   
+   # Or save to a file
+   base64 github-app-private-key.pem > github-app-private-key-base64.txt
+   ```
+4. Store the following as GitHub secrets in your repository:
+   - `GITHUB_PROVIDER_APP_ID` - The GitHub App ID
+   - `GITHUB_PROVIDER_INSTALLATION_ID` - The GitHub App installation ID
+   - `GITHUB_PROVIDER_PRIVATE_KEY` - The base64 encoded private key from step 3
+
+5. Pass these secrets to the workflow:
+   ```yml
+   jobs:
+     terraform:
+       uses: appvia/appvia-cicd-workflows/.github/workflows/terraform-plan-and-apply-aws.yml@main
+       name: Plan and Apply
+       secrets:
+         github-provider-app-id: ${{ secrets.GITHUB_PROVIDER_APP_ID }}
+         github-provider-installation-id: ${{ secrets.GITHUB_PROVIDER_INSTALLATION_ID }}
+         github-provider-private-key: ${{ secrets.GITHUB_PROVIDER_PRIVATE_KEY }}
+       with:
+         aws-account: 123456789012
+         # ... other inputs
+   ```
+
+6. Configure the GitHub provider in your Terraform code:
+   ```hcl
+   provider "github" {
+     owner = "my-organization"
+     app_auth {}  # Will use environment variables set by the workflow
+   }
+   ```
+
+The workflow automatically sets the required environment variables (`GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PEM_FILE`) that the GitHub provider uses for authentication.


### PR DESCRIPTION
- Add secrets for GitHub App authentication (app-id, installation-id, private-key)
- Private key must be base64 encoded to avoid GitHub Actions secret masking issues
- Decode private key and write to a file during workflow execution in an ephemeral temp directory
- Set GITHUB_APP_* environment variables for Terraform GitHub provider
- Update documentation with usage instructions