### PR TITLE
fix: provide github private key contents to provider

### DIFF
--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -395,6 +395,16 @@ jobs:
           terraform-version: ${{ inputs.terraform-version }}
           working-directory: ${{ inputs.working-directory }}
           use-env-as-suffix: ${{ inputs.use-env-as-suffix }}
+      - name: Add GitHub provider credentials to environment
+        run: |
+          if [ -n "${{ secrets.gh-provider-app-id }}" ] && [ -n "${{ secrets.gh-provider-installation-id }}" ] && [ -n "${{ secrets.gh-provider-private-key }}" ]; then
+            echo "GITHUB_APP_ID=${{ secrets.gh-provider-app-id }}" >> "${GITHUB_ENV}"
+            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.gh-provider-installation-id }}" >> "${GITHUB_ENV}"
+            # Decode base64 encoded private key and write to file
+            echo "${{ secrets.gh-provider-private-key }}" | base64 --decode > /tmp/github_provider.pem
+          else
+            echo "GitHub provider credentials not provided."
+          fi
       - name: Terraform Validate
         id: validate
         run: terraform -chdir=${{ inputs.terraform-dir }} validate -no-color
@@ -413,17 +423,6 @@ jobs:
             echo "TF_VAR_FILE=${{ inputs.terraform-values-file }}" >> "${GITHUB_ENV}"
           else
             echo "TF_VAR_FILE=values/${{ inputs.environment }}.tfvars" >> "${GITHUB_ENV}"
-          fi
-      - name: Add GitHub provider credentials to environment
-        run: |
-          if [ -n "${{ secrets.gh-provider-app-id }}" ] && [ -n "${{ secrets.gh-provider-installation-id }}" ] && [ -n "${{ secrets.gh-provider-private-key }}" ]; then
-            echo "GITHUB_APP_ID=${{ secrets.gh-provider-app-id }}" >> "${GITHUB_ENV}"
-            echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.gh-provider-installation-id }}" >> "${GITHUB_ENV}"
-            # Decode base64 encoded private key and write to file
-            echo "${{ secrets.gh-provider-private-key }}" | base64 -d > ${RUNNER_TEMP}/github-app-private-key.pem
-            echo "GITHUB_APP_PEM_FILE=${RUNNER_TEMP}/github-app-private-key.pem" >> "${GITHUB_ENV}"
-          else
-            echo "GitHub provider credentials not provided."
           fi
       - name: Terraform Plan
         id: plan
@@ -473,6 +472,12 @@ jobs:
           include-hidden-files: true
           path: ${{ inputs.additional-dir }}
           retention-days: 14
+      - name: Cleanup GitHub provider key
+        if: always()
+        run: |
+          if [ -n "${{ secrets.gh-provider-app-id }}" ] && [ -n "${{ secrets.gh-provider-installation-id }}" ] && [ -n "${{ secrets.gh-provider-private-key }}" ]; then
+            rm /tmp/github_provider.pem
+          fi
 
   terraform-checkov:
     name: "Static Security Analysis - Checkov"
@@ -746,8 +751,9 @@ jobs:
             echo "GITHUB_APP_ID=${{ secrets.gh-provider-app-id }}" >> "${GITHUB_ENV}"
             echo "GITHUB_APP_INSTALLATION_ID=${{ secrets.gh-provider-installation-id }}" >> "${GITHUB_ENV}"
             # Decode base64 encoded private key and write to file
-            echo "${{ secrets.gh-provider-private-key }}" | base64 -d > ${RUNNER_TEMP}/github-app-private-key.pem
-            echo "GITHUB_APP_PEM_FILE=${RUNNER_TEMP}/github-app-private-key.pem" >> "${GITHUB_ENV}"
+            echo "${{ secrets.gh-provider-private-key }}" | base64 --decode > /tmp/github_provider.pem
+          else
+            echo "GitHub provider credentials not provided."
           fi
       - name: Terraform Apply
         run: |
@@ -758,3 +764,9 @@ jobs:
             -lock-timeout=${{ inputs.terraform-lock-timeout }} \
             ${{ inputs.terraform-apply-extra-args }} \
             tfplan
+      - name: Cleanup GitHub provider key
+        if: always()
+        run: |
+          if [ -n "${{ secrets.gh-provider-app-id }}" ] && [ -n "${{ secrets.gh-provider-installation-id }}" ] && [ -n "${{ secrets.gh-provider-private-key }}" ]; then
+            rm /tmp/github_provider.pem
+          fi

--- a/docs/terraform-plan-and-apply-aws.md
+++ b/docs/terraform-plan-and-apply-aws.md
@@ -88,8 +88,10 @@ The workflow supports the Terraform GitHub provider through GitHub App authentic
    ```hcl
    provider "github" {
      owner = "my-organization"
-     app_auth {}  # Will use environment variables set by the workflow
+     app_auth {
+       pem_file = file("/tmp/github_provider.pem")
+     } 
    }
    ```
 
-The workflow automatically sets the required environment variables (`GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PEM_FILE`) that the GitHub provider uses for authentication.
+The workflow automatically sets the required environment variables (`GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`) and exports the decoded private key in `/tmp/github_provider.pem`. The private key is cleaned up at the end of the workflow.


### PR DESCRIPTION
This PR addresses a couple of issues:

- Despite misleading documentation and commit history, the GitHub provider requires the *content* of the private key as an input, providing the path to the key is insufficent. This PR saves the decoded file to tmp space and then makes it available for the provider to consume.
- When using the GitHub provider with credentials provided through environment variables, the variables must be available during the terraform validation step otherwise validation will fail. This PR bumps the step which exports the environment variables earlier so the variables are available for the validation. 