### PR TITLE
Add Trivy checksum verification to workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # - dependency-name: "aquasecurity/setup-trivy" # temporary ignore

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -90,8 +90,15 @@ on:
       trivy-version:
         description: "Trivy version to use"
         required: false
-        default: "latest"
+        default: "v0.69.3"
         type: string
+      trivy-sha256:
+        description: 'Trivy sha256 checksum to verify'
+        required: false
+        type: string
+        default: |
+          d860265c7ebd8128c349d063c91e8f32b26b730d14c2ce85e187fef8be70d72d
+          8266084a71d2e6a2333bc2c69b91c93c26dee9ef39ac2587ace2df54cc9b746b
       fail-on-vulnerabilities:
         description: "Fail build if vulnerabilities found"
         required: false
@@ -198,6 +205,22 @@ jobs:
           file: ${{ inputs.dockerfile-path }}
           push: false
           tags: docker-build-${{ github.sha }}
+      - name: Setup Trivy
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6 - see dependabot.yml ignore rule
+        with:
+          version: ${{ inputs.trivy-version }}
+      - name: Verify Trivy Checksum # step added to verify trivy v0.69.3 binary
+        shell: bash
+        run: |
+            EXPECTED_SHA_COLLECTION="${{ inputs.trivy-sha256 }}"
+            ACTUAL_SHA="$(sha256sum $(which trivy) | awk '{print $1}')"
+            echo "Trivy SHA: $ACTUAL_SHA"
+            if echo "$EXPECTED_SHA_COLLECTION" | grep -Fq "$ACTUAL_SHA"; then
+              echo "Trivy binary checksum verified successfully."
+            else
+              echo "Error: Trivy binary checksum mismatch!"
+              exit 1
+            fi
       - name: Run Trivy vulnerability scanner
         id: scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -213,7 +213,7 @@ jobs:
         shell: bash
         run: |
             EXPECTED_SHA_COLLECTION="${{ inputs.trivy-sha256 }}"
-            ACTUAL_SHA="$(sha256sum $(which trivy) | awk '{print $1}')"
+            ACTUAL_SHA="$(sha256sum "$(which trivy)" | awk '{print $1}')"
             echo "Trivy SHA: $ACTUAL_SHA"
             if echo "$EXPECTED_SHA_COLLECTION" | grep -Fq "$ACTUAL_SHA"; then
               echo "Trivy binary checksum verified successfully."

--- a/.github/workflows/terraform-module-validation.yml
+++ b/.github/workflows/terraform-module-validation.yml
@@ -98,6 +98,14 @@ on:
         required: false
         type: string
 
+      trivy-sha256:
+        description: 'Trivy sha256 checksum to verify'
+        required: false
+        type: string
+        default: |
+          d860265c7ebd8128c349d063c91e8f32b26b730d14c2ce85e187fef8be70d72d
+          8266084a71d2e6a2333bc2c69b91c93c26dee9ef39ac2587ace2df54cc9b746b
+
       working-directory:
         default: "."
         description: "Working directory"
@@ -302,6 +310,22 @@ jobs:
           terraform-init-extra-args: ${{ inputs.terraform-init-extra-args }}
           terraform-version: ${{ inputs.terraform-version }}
           working-directory: ${{ inputs.working-directory }}
+      - name: Setup Trivy
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6 - see dependabot.yml ignore rule
+        with:
+          version: ${{ inputs.trivy-version }}
+      - name: Verify Trivy Checksum # step added to verify trivy v0.69.3 binary
+        shell: bash
+        run: |
+            EXPECTED_SHA_COLLECTION="${{ inputs.trivy-sha256 }}"
+            ACTUAL_SHA="$(sha256sum $(which trivy) | awk '{print $1}')"
+            echo "Trivy SHA: $ACTUAL_SHA"
+            if echo "$EXPECTED_SHA_COLLECTION" | grep -Fq "$ACTUAL_SHA"; then
+              echo "Trivy binary checksum verified successfully."
+            else
+              echo "Error: Trivy binary checksum mismatch!"
+              exit 1
+            fi
       - name: Run Trivy vulnerability
         id: security
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0

--- a/.github/workflows/terraform-module-validation.yml
+++ b/.github/workflows/terraform-module-validation.yml
@@ -318,7 +318,7 @@ jobs:
         shell: bash
         run: |
             EXPECTED_SHA_COLLECTION="${{ inputs.trivy-sha256 }}"
-            ACTUAL_SHA="$(sha256sum $(which trivy) | awk '{print $1}')"
+            ACTUAL_SHA="$(sha256sum "$(which trivy)" | awk '{print $1}')"
             echo "Trivy SHA: $ACTUAL_SHA"
             if echo "$EXPECTED_SHA_COLLECTION" | grep -Fq "$ACTUAL_SHA"; then
               echo "Trivy binary checksum verified successfully."

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -545,7 +545,7 @@ jobs:
         shell: bash
         run: |
             EXPECTED_SHA_COLLECTION="${{ inputs.trivy-sha256 }}"
-            ACTUAL_SHA="$(sha256sum $(which trivy) | awk '{print $1}')"
+            ACTUAL_SHA="$(sha256sum "$(which trivy)" | awk '{print $1}')"
             echo "Trivy SHA: $ACTUAL_SHA"
             if echo "$EXPECTED_SHA_COLLECTION" | grep -Fq "$ACTUAL_SHA"; then
               echo "Trivy binary checksum verified successfully."

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -161,6 +161,13 @@ on:
         description: "The version of trivy to use"
         required: false
         type: string
+      trivy-sha256:
+        description: 'Trivy sha256 checksum to verify'
+        required: false
+        type: string
+        default: |
+          d860265c7ebd8128c349d063c91e8f32b26b730d14c2ce85e187fef8be70d72d
+          8266084a71d2e6a2333bc2c69b91c93c26dee9ef39ac2587ace2df54cc9b746b
       working-directory:
         default: "."
         description: "The working directory to run terraform commands in"
@@ -530,6 +537,22 @@ jobs:
           else
             echo "TF_VAR_FILE=values/${{ inputs.environment }}.tfvars" >> "${GITHUB_ENV}"
           fi
+      - name: Setup Trivy
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514 # v0.2.6 - see dependabot.yml ignore rule
+        with:
+          version: ${{ inputs.trivy-version }}
+      - name: Verify Trivy Checksum # step added to verify trivy v0.69.3 binary
+        shell: bash
+        run: |
+            EXPECTED_SHA_COLLECTION="${{ inputs.trivy-sha256 }}"
+            ACTUAL_SHA="$(sha256sum $(which trivy) | awk '{print $1}')"
+            echo "Trivy SHA: $ACTUAL_SHA"
+            if echo "$EXPECTED_SHA_COLLECTION" | grep -Fq "$ACTUAL_SHA"; then
+              echo "Trivy binary checksum verified successfully."
+            else
+              echo "Error: Trivy binary checksum mismatch!"
+              exit 1
+            fi
       - name: Run Trivy vulnerability
         id: security
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0


### PR DESCRIPTION
- Introduce trivy-sha256 input for checksum verification
- Update Trivy version to v0.69.3 in workflows
- Add steps to verify Trivy binary checksum in docker-build, terraform-module-validation, and terraform-plan-and-apply-aws workflows to ensure integrity of the Trivy binary.