### PR TITLE
feat: add SHA pinning validation for reusable workflow references

### DIFF
--- a/.github/workflows/github-workflow-validation.yml
+++ b/.github/workflows/github-workflow-validation.yml
@@ -26,3 +26,15 @@ jobs:
       - name: Run Actionlint
         id: actionlint
         run: actionlint ${{ inputs.workflows-path }}/*.yml
+      - name: Check reusable workflow SHA Pinning
+        env:
+          WORKFLOWS_PATH: "${{ inputs.workflows-path }}"
+        run: |
+          violations=$(grep -E 'uses:.*appvia/appvia-cicd-workflows' "$WORKFLOWS_PATH"/*.yml \
+            | grep -vE '@[0-9a-f]{40}' || true)
+          if [ -n "$violations" ]; then
+            echo "ERROR: The following reusable workflow references do not use a commit SHA:"
+            echo "$violations"
+            exit 1
+          fi
+          echo "All reusable workflow references are properly SHA pinned."

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 16
+          node-version: 20
       - name: Install Dependencies
         run: npm install @commitlint/config-conventional @commitlint/cli
       - name: Run Commitlint

--- a/scripts/audit_sha_pinning.sh
+++ b/scripts/audit_sha_pinning.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ORG="${1:-appvia}"
+
+if ! command -v gh &>/dev/null; then
+  echo "ERROR: gh CLI not found. Install from https://cli.github.com" >&2
+  exit 1
+fi
+
+REPOS=$(gh repo list "$ORG" --limit 500 --json name,isArchived \
+  | jq -r '.[] | select(.isArchived == false) | select(.name | startswith("terraform-aws-")) | .name')
+
+printf "%-50s %-10s %-12s %-10s\n" "REPO" "RENOVATE" "PIN_DIGESTS" "SHA_REFS"
+printf "%-50s %-10s %-12s %-10s\n" "----" "--------" "-----------" "--------"
+
+while IFS= read -r repo; do
+    if ! gh api "repos/$ORG/$repo/contents/.github/workflows/terraform.yml" > /dev/null 2>&1; then
+        continue
+    fi
+
+# Check Renovate Config
+renovate_file=""
+for config in "renovate.json" "renovate.json5" ".renovaterc" ".github/renovate.json" ".github/renovate.json5"; do
+    if gh api "repos/$ORG/$repo/contents/$config" > /dev/null 2>&1; then
+        renovate_file="$config"
+        break
+    fi
+done
+
+if [ -n "$renovate_file" ]; then
+    renovate_status="PASS"
+    content=$(gh api "repos/$ORG/$repo/contents/$renovate_file" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null)
+    if echo "$content" | grep -q '"pinDigests".*true'; then
+        pin_status="PASS"
+    else
+        pin_status="FAIL"
+    fi
+else
+    renovate_status="FAIL"
+    pin_status="N/A"
+fi
+
+# Check SHA refs in terraform.yml
+tf_content=$(gh api "repos/$ORG/$repo/contents/.github/workflows/terraform.yml" \
+    --jq '.content' 2>/dev/null | base64 -d 2>/dev/null)
+    cicd_refs=$(echo "$tf_content" | grep -E 'uses:.*appvia/appvia-cicd-workflows' || true)
+
+if [ -z "$cicd_refs" ]; then
+    sha_status="NO_REFS"
+else
+    non_sha=$(echo "$cicd_refs" | grep -vE '@[0-9a-f]{40}' || true)
+    if [ -n "$non_sha" ]; then
+        sha_status="FAIL"
+    else
+        sha_status="PASS"
+    fi 
+fi 
+
+printf "%-50s %-10s %-12s %-10s\n" "$repo" "$renovate_status" "$pin_status" "$sha_status"
+done <<< "$REPOS"


### PR DESCRIPTION
## what

  - Adds a validation step to github-workflow-validation.yml that fails if any reusable workflow reference to appvia/appvia-cicd-workflows uses a tag or branch instead of a full commit SHA
  - Adds scripts/audit_sha_pinning.sh to discover non-compliant terraform-aws-* repositories across an org

## why

  - Reusable workflow references pinned to tags or branches are mutable — a tag move or force-push could silently change what executes without review
  - This guardrail prevents regression by blocking PRs that introduce non-SHA references going forward
  - Part of supply-chain security standardisation across terraform-aws-* repositories (SA-689)

## references

- [SA-689](https://appvia.atlassian.net/browse/SA-689)


[SA-689]: https://appvia.atlassian.net/browse/SA-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ