### PR TITLE
Feat/terraform encryption

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,6 +61,8 @@ docs/              # Markdown docs for each workflow
 |---|---|
 | `terraform-bootstrap` | Setup Terraform + AWS OIDC auth + S3 backend init |
 | `terraform-bootstrap-noauth` | Setup Terraform without AWS auth (for lint/validate jobs) |
+| `terraform-plan-encrypt` | Encrypt plan artifacts (tfplan, tfplan.json) using AES-256-CBC |
+| `terraform-plan-decrypt` | Decrypt plan artifacts encrypted by terraform-plan-encrypt |
 | `terragrunt-bootstrap` | Setup Terragrunt + Terraform + AWS OIDC auth |
 | `terragrunt-bootstrap-unauth` | Setup Terragrunt without AWS auth |
 | `terragrunt-diff` | Compare Terragrunt inputs between PR and main, post PR comment |
@@ -104,12 +106,22 @@ docs/              # Markdown docs for each workflow
 - Comments include workflow run links, actor, and per-job status with emoji indicators
 - Terragrunt workflows aggregate matrix job results into a single comment
 
+### Plan Artifact Encryption
+
+- Controlled by `enable-plan-encryption` input (default: true)
+- Encrypts `tfplan` (binary) and `tfplan.json` using AES-256-CBC via `openssl`
+- Checksum computed on unencrypted plan, verified after decryption
+- Key management: ephemeral key generated per run (via `openssl rand -hex 32`), passed between jobs as masked job output
+- Static key override: provide `encryption-key` secret to use a fixed key instead
+- Unencrypted files in artifact: `tfplan-simple`, `tfplan-summary`, `tfplan.stdout`, `tfplan.checksum`
+- Uses `terraform-plan-encrypt` and `terraform-plan-decrypt` composite actions
+
 ### Job Structure
 
 - Debug mode job: determines `TF_LOG` level from runner debug mode
 - Bootstrap jobs: use composite actions, capture step outcomes as outputs
-- Plan jobs: upload `tfplan` as artifact with SHA256 checksums
-- Apply jobs: validate checksums, use GitHub environment protection (`environment: ${{ inputs.environment }}`)
+- Plan jobs: upload `tfplan` as artifact with SHA256 checksums and optional encryption
+- Apply jobs: decrypt (if encrypted), validate checksums, use GitHub environment protection (`environment: ${{ inputs.environment }}`)
 - Security scanning: Trivy and Checkov (both toggleable via `enable-*` inputs)
 - Cost estimation: Infracost (optional, requires API key)
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -111,8 +111,7 @@ docs/              # Markdown docs for each workflow
 - Controlled by `enable-plan-encryption` input (default: true)
 - Encrypts `tfplan` (binary) and `tfplan.json` using AES-256-CBC via `openssl`
 - Checksum computed on unencrypted plan, verified after decryption
-- Key management: ephemeral key generated per run (via `openssl rand -hex 32`), passed between jobs as masked job output
-- Static key override: provide `encryption-key` secret to use a fixed key instead
+- Key management: static symmetric key provided via `encryption-key` secret (generate with `openssl rand -base64 32`)
 - Unencrypted files in artifact: `tfplan-simple`, `tfplan-summary`, `tfplan.stdout`, `tfplan.checksum`
 - Uses `terraform-plan-encrypt` and `terraform-plan-decrypt` composite actions
 

--- a/.github/actions/terraform-plan-decrypt/action.yml
+++ b/.github/actions/terraform-plan-decrypt/action.yml
@@ -22,7 +22,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        echo "${{ inputs.encryption-key }}" > /tmp/tfplan-enc-key
+        umask 077
+        printf '%s' "${{ inputs.encryption-key }}" > /tmp/tfplan-enc-key
 
     - name: Verify Encryption Key
       shell: bash

--- a/.github/actions/terraform-plan-decrypt/action.yml
+++ b/.github/actions/terraform-plan-decrypt/action.yml
@@ -37,6 +37,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
+        set -euo pipefail
         for file in ${{ inputs.files }}; do
           if [ -f "${file}.enc" ]; then
             echo "Decrypting ${file}.enc..."

--- a/.github/actions/terraform-plan-decrypt/action.yml
+++ b/.github/actions/terraform-plan-decrypt/action.yml
@@ -1,0 +1,55 @@
+---
+name: Terraform Plan Decrypt
+description: "Decrypts Terraform plan artifacts that were encrypted using AES-256-CBC"
+inputs:
+  encryption-key:
+    description: "Static encryption key. If not set, expects key at /tmp/tfplan-enc-key"
+    required: false
+  working-directory:
+    description: "The working directory where encrypted plan files are located"
+    required: false
+    default: "."
+  files:
+    description: "Space-separated list of files to decrypt (without .enc suffix)"
+    required: false
+    default: "tfplan tfplan.json"
+
+runs:
+  using: composite
+  steps:
+    - name: Write Static Encryption Key
+      if: inputs.encryption-key != ''
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        echo "${{ inputs.encryption-key }}" > /tmp/tfplan-enc-key
+
+    - name: Verify Encryption Key
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        if [ ! -f /tmp/tfplan-enc-key ] || [ ! -s /tmp/tfplan-enc-key ]; then
+          echo "::error::Encryption key not found at /tmp/tfplan-enc-key. Either provide the encryption-key input or generate a key before calling this action."
+          exit 1
+        fi
+
+    - name: Decrypt Plan Files
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        for file in ${{ inputs.files }}; do
+          if [ -f "${file}.enc" ]; then
+            echo "Decrypting ${file}.enc..."
+            openssl enc -aes-256-cbc -d -pbkdf2 -iter 100000 \
+              -in "${file}.enc" -out "${file}" -pass file:/tmp/tfplan-enc-key
+            rm "${file}.enc"
+            echo "Decrypted ${file}.enc -> ${file}"
+          else
+            echo "::warning::File ${file}.enc not found, skipping decryption"
+          fi
+        done
+
+    - name: Clean Up Encryption Key
+      if: always()
+      shell: bash
+      run: rm -f /tmp/tfplan-enc-key

--- a/.github/actions/terraform-plan-encrypt/action.yml
+++ b/.github/actions/terraform-plan-encrypt/action.yml
@@ -1,0 +1,55 @@
+---
+name: Terraform Plan Encrypt
+description: "Encrypts Terraform plan artifacts using AES-256-CBC before upload"
+inputs:
+  encryption-key:
+    description: "Static encryption key. If not set, expects key at /tmp/tfplan-enc-key"
+    required: false
+  working-directory:
+    description: "The working directory where plan files are located"
+    required: false
+    default: "."
+  files:
+    description: "Space-separated list of files to encrypt"
+    required: false
+    default: "tfplan tfplan.json"
+
+runs:
+  using: composite
+  steps:
+    - name: Write Static Encryption Key
+      if: inputs.encryption-key != ''
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        echo "${{ inputs.encryption-key }}" > /tmp/tfplan-enc-key
+
+    - name: Verify Encryption Key
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        if [ ! -f /tmp/tfplan-enc-key ] || [ ! -s /tmp/tfplan-enc-key ]; then
+          echo "::error::Encryption key not found at /tmp/tfplan-enc-key. Either provide the encryption-key input or generate a key before calling this action."
+          exit 1
+        fi
+
+    - name: Encrypt Plan Files
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        for file in ${{ inputs.files }}; do
+          if [ -f "${file}" ]; then
+            echo "Encrypting ${file}..."
+            openssl enc -aes-256-cbc -salt -pbkdf2 -iter 100000 \
+              -in "${file}" -out "${file}.enc" -pass file:/tmp/tfplan-enc-key
+            rm "${file}"
+            echo "Encrypted ${file} -> ${file}.enc"
+          else
+            echo "::warning::File ${file} not found, skipping encryption"
+          fi
+        done
+
+    - name: Clean Up Encryption Key
+      if: always()
+      shell: bash
+      run: rm -f /tmp/tfplan-enc-key

--- a/.github/actions/terraform-plan-encrypt/action.yml
+++ b/.github/actions/terraform-plan-encrypt/action.yml
@@ -22,7 +22,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        echo "${{ inputs.encryption-key }}" > /tmp/tfplan-enc-key
+        umask 077
+        printf '%s' "${{ inputs.encryption-key }}" > /tmp/tfplan-enc-key
 
     - name: Verify Encryption Key
       shell: bash

--- a/.github/actions/terraform-plan-encrypt/action.yml
+++ b/.github/actions/terraform-plan-encrypt/action.yml
@@ -37,6 +37,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
+        set -euo pipefail
         for file in ${{ inputs.files }}; do
           if [ -f "${file}" ]; then
             echo "Encrypting ${file}..."

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -9,6 +9,9 @@ on:
       actions-secret:
         description: "The GitHub App secret for the Actions App"
         required: false
+      encryption-key:
+        description: "Static encryption key for plan artifacts. If not set, an ephemeral key is generated per run."
+        required: false
 
     inputs:
       confirmation:
@@ -71,6 +74,12 @@ on:
         description: "The environment to deploy to"
         required: false
         type: string
+
+      enable-plan-encryption:
+        default: true
+        description: "Whether to encrypt Terraform plan artifacts at rest"
+        required: false
+        type: boolean
 
       enable-private-access:
         description: Optional flag to state if terraform requires pulling private modules
@@ -180,9 +189,27 @@ jobs:
       result-s3-backend-check: ${{ steps.s3-backend-check.outcome }}
       result-plan: ${{ steps.plan.outcome }}
       plan-stdout: ${{ steps.plan.outputs.stdout }}
+      encryption-key: ${{ steps.encryption-key.outputs.key }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Generate Encryption Key
+        id: encryption-key
+        if: inputs.enable-plan-encryption
+        shell: bash
+        run: |
+          if [ -n "$ENCRYPTION_KEY_SECRET" ]; then
+            echo "Using static encryption key from secret"
+            echo "$ENCRYPTION_KEY_SECRET" > /tmp/tfplan-enc-key
+          else
+            echo "Generating ephemeral encryption key"
+            ENCRYPTION_KEY=$(openssl rand -hex 32)
+            echo "::add-mask::${ENCRYPTION_KEY}"
+            echo "${ENCRYPTION_KEY}" > /tmp/tfplan-enc-key
+            echo "key=${ENCRYPTION_KEY}" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          ENCRYPTION_KEY_SECRET: ${{ secrets.encryption-key }}
       - name: Terraform Bootstrap
         id: bootstrap
         uses: appvia/appvia-cicd-workflows/.github/actions/terraform-bootstrap@da2bf7ed16cc9778fedff463249466ca88069df5 # main
@@ -238,6 +265,13 @@ jobs:
       - name: Terraform Plan JSON Output
         run: |
           terraform -chdir=${{ inputs.terraform-dir }} show -json tfplan > tfplan.json
+      - name: Calculate Plan Checksum
+        run: sha256sum tfplan > tfplan.checksum
+      - name: Encrypt Plan Artifacts
+        if: inputs.enable-plan-encryption
+        uses: appvia/appvia-cicd-workflows/.github/actions/terraform-plan-encrypt@feat/terraform-encryption # TODO: pin to SHA once merged
+        with:
+          working-directory: ${{ inputs.working-directory }}
       - name: Upload tfplan
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -296,12 +330,51 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tfplan-${{ inputs.environment }}
+        continue-on-error: true
+      - name: Restore Encryption Key
+        if: inputs.enable-plan-encryption
+        shell: bash
+        run: |
+          if [ -n "$ENCRYPTION_KEY_SECRET" ]; then
+            echo "$ENCRYPTION_KEY_SECRET" > /tmp/tfplan-enc-key
+          else
+            EPHEMERAL_KEY="${{ needs.terraform-plan.outputs.encryption-key }}"
+            echo "::add-mask::${EPHEMERAL_KEY}"
+            echo "${EPHEMERAL_KEY}" > /tmp/tfplan-enc-key
+          fi
+        env:
+          ENCRYPTION_KEY_SECRET: ${{ secrets.encryption-key }}
+      - name: Decrypt Plan Artifacts
+        if: inputs.enable-plan-encryption
+        uses: appvia/appvia-cicd-workflows/.github/actions/terraform-plan-decrypt@feat/terraform-encryption # TODO: pin to SHA once merged
+        with:
+          working-directory: ${{ inputs.working-directory }}
+      - name: Check Artifact Availability
+        run: |
+          if [ ! -f tfplan ]; then
+            echo "tfplan artifact not found. Please regenerate the plan."
+            exit 1
+          fi
       - name: Download Additional Directories
         if: inputs.additional-dir
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: additional-dir-${{ inputs.environment }}
           path: ${{ inputs.additional-dir }}
+      - name: Validate Plan Checksum
+        run: |
+          if [ ! -f tfplan.checksum ]; then
+            echo "Checksum file is missing. The tfplan artifact may not have been generated or uploaded correctly. Halting Terraform Apply phase."
+            exit 1
+          fi
+          echo "Validating the checksum of the tfplan artifact..."
+          if sha256sum -c tfplan.checksum; then
+            echo "Checksum validation succeeded. The tfplan artifact is intact and matches the original plan."
+          else
+            echo "Checksum validation failed. The tfplan artifact has been modified or tampered with since the plan was generated."
+            echo "Halting Terraform Apply phase to ensure the integrity of the deployment process."
+            exit 1
+          fi
       - name: Terraform Apply
         run: |
           terraform apply -auto-approve -input=false \

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -10,7 +10,7 @@ on:
         description: "The GitHub App secret for the Actions App"
         required: false
       encryption-key:
-        description: "Static encryption key for plan artifacts. If not set, an ephemeral key is generated per run."
+        description: "Encryption key for plan artifacts. Required when enable-plan-encryption is true."
         required: false
 
     inputs:
@@ -189,27 +189,9 @@ jobs:
       result-s3-backend-check: ${{ steps.s3-backend-check.outcome }}
       result-plan: ${{ steps.plan.outcome }}
       plan-stdout: ${{ steps.plan.outputs.stdout }}
-      encryption-key: ${{ steps.encryption-key.outputs.key }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - name: Generate Encryption Key
-        id: encryption-key
-        if: inputs.enable-plan-encryption
-        shell: bash
-        run: |
-          if [ -n "$ENCRYPTION_KEY_SECRET" ]; then
-            echo "Using static encryption key from secret"
-            echo "$ENCRYPTION_KEY_SECRET" > /tmp/tfplan-enc-key
-          else
-            echo "Generating ephemeral encryption key"
-            ENCRYPTION_KEY=$(openssl rand -hex 32)
-            echo "::add-mask::${ENCRYPTION_KEY}"
-            echo "${ENCRYPTION_KEY}" > /tmp/tfplan-enc-key
-            echo "key=${ENCRYPTION_KEY}" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          ENCRYPTION_KEY_SECRET: ${{ secrets.encryption-key }}
       - name: Terraform Bootstrap
         id: bootstrap
         uses: appvia/appvia-cicd-workflows/.github/actions/terraform-bootstrap@da2bf7ed16cc9778fedff463249466ca88069df5 # main
@@ -271,6 +253,7 @@ jobs:
         if: inputs.enable-plan-encryption
         uses: appvia/appvia-cicd-workflows/.github/actions/terraform-plan-encrypt@feat/terraform-encryption # TODO: pin to SHA once merged
         with:
+          encryption-key: ${{ secrets.encryption-key }}
           working-directory: ${{ inputs.working-directory }}
       - name: Upload tfplan
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -331,23 +314,11 @@ jobs:
         with:
           name: tfplan-${{ inputs.environment }}
         continue-on-error: true
-      - name: Restore Encryption Key
-        if: inputs.enable-plan-encryption
-        shell: bash
-        run: |
-          if [ -n "$ENCRYPTION_KEY_SECRET" ]; then
-            echo "$ENCRYPTION_KEY_SECRET" > /tmp/tfplan-enc-key
-          else
-            EPHEMERAL_KEY="${{ needs.terraform-plan.outputs.encryption-key }}"
-            echo "::add-mask::${EPHEMERAL_KEY}"
-            echo "${EPHEMERAL_KEY}" > /tmp/tfplan-enc-key
-          fi
-        env:
-          ENCRYPTION_KEY_SECRET: ${{ secrets.encryption-key }}
       - name: Decrypt Plan Artifacts
         if: inputs.enable-plan-encryption
         uses: appvia/appvia-cicd-workflows/.github/actions/terraform-plan-decrypt@feat/terraform-encryption # TODO: pin to SHA once merged
         with:
+          encryption-key: ${{ secrets.encryption-key }}
           working-directory: ${{ inputs.working-directory }}
       - name: Check Artifact Availability
         run: |

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -259,7 +259,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tfplan-${{ inputs.environment }}
-          path: "tfplan*"
+          path: "${{ inputs.working-directory }}/tfplan*"
           retention-days: 14
       - name: Optional Additional Directory Upload
         if: inputs.additional-dir-optional && inputs.additional-dir != ''
@@ -313,6 +313,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tfplan-${{ inputs.environment }}
+          path: ${{ inputs.working-directory }}
         continue-on-error: true
       - name: Decrypt Plan Artifacts
         if: inputs.enable-plan-encryption

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -324,11 +324,13 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tfplan-${{ inputs.environment }}-${{ github.event.pull_request.number }}
+          path: ${{ inputs.working-directory }}
       - name: Decrypt Plan Artifacts
         if: inputs.enable-plan-encryption
         uses: appvia/appvia-cicd-workflows/.github/actions/terraform-plan-decrypt@feat/terraform-encryption # TODO: pin to SHA once merged
         with:
           encryption-key: ${{ secrets.encryption-key }}
+          working-directory: ${{ inputs.working-directory }}
           files: tfplan.json
       - name: Generate Infracost Cost Estimate
         run: |
@@ -458,7 +460,7 @@ jobs:
         with:
           name: tfplan-${{ inputs.environment }}-${{ github.event.pull_request.number }}
           compression-level: 9
-          path: "tfplan*"
+          path: "${{ inputs.working-directory }}/tfplan*"
           retention-days: 14
       - name: Optional Additional Directory Upload
         if: inputs.additional-dir-optional && inputs.additional-dir != ''
@@ -717,6 +719,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tfplan-${{ inputs.environment }}-${{ github.event.pull_request.number }}
+          path: ${{ inputs.working-directory }}
         continue-on-error: true
       - name: Decrypt Plan Artifacts
         if: inputs.enable-plan-encryption

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -18,6 +18,9 @@ on:
       environment-files:
         description: "A JSON object of file paths and their base64 encoded contents to be created in the working directory"
         required: false
+      encryption-key:
+        description: "Static encryption key for plan artifacts. If not set, an ephemeral key is generated per run."
+        required: false
 
     inputs:
       additional-dir:
@@ -74,6 +77,11 @@ on:
       enable-commitlint:
         default: true
         description: "Whether to run commitlint on the commit message"
+        required: false
+        type: boolean
+      enable-plan-encryption:
+        default: true
+        description: "Whether to encrypt Terraform plan artifacts at rest"
         required: false
         type: boolean
       enable-terraform-apply:
@@ -316,6 +324,24 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tfplan-${{ inputs.environment }}-${{ github.event.pull_request.number }}
+      - name: Restore Encryption Key
+        if: inputs.enable-plan-encryption
+        shell: bash
+        run: |
+          if [ -n "$ENCRYPTION_KEY_SECRET" ]; then
+            echo "$ENCRYPTION_KEY_SECRET" > /tmp/tfplan-enc-key
+          else
+            EPHEMERAL_KEY="${{ needs.terraform-plan.outputs.encryption-key }}"
+            echo "::add-mask::${EPHEMERAL_KEY}"
+            echo "${EPHEMERAL_KEY}" > /tmp/tfplan-enc-key
+          fi
+        env:
+          ENCRYPTION_KEY_SECRET: ${{ secrets.encryption-key }}
+      - name: Decrypt Plan Artifacts
+        if: inputs.enable-plan-encryption
+        uses: appvia/appvia-cicd-workflows/.github/actions/terraform-plan-decrypt@feat/terraform-encryption # TODO: pin to SHA once merged
+        with:
+          files: tfplan.json
       - name: Generate Infracost Cost Estimate
         run: |
           infracost breakdown --path=tfplan.json \
@@ -345,11 +371,29 @@ jobs:
       result-validate: ${{ steps.validate.outcome }}
       result-s3-backend-check: ${{ steps.s3-backend-check.outcome }}
       result-plan: ${{ steps.plan.outcome }}
+      encryption-key: ${{ steps.encryption-key.outputs.key }}
     env:
       TF_LOG: ${{ needs.debug-mode.outputs.tf_log }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Generate Encryption Key
+        id: encryption-key
+        if: inputs.enable-plan-encryption
+        shell: bash
+        run: |
+          if [ -n "$ENCRYPTION_KEY_SECRET" ]; then
+            echo "Using static encryption key from secret"
+            echo "$ENCRYPTION_KEY_SECRET" > /tmp/tfplan-enc-key
+          else
+            echo "Generating ephemeral encryption key"
+            ENCRYPTION_KEY=$(openssl rand -hex 32)
+            echo "::add-mask::${ENCRYPTION_KEY}"
+            echo "${ENCRYPTION_KEY}" > /tmp/tfplan-enc-key
+            echo "key=${ENCRYPTION_KEY}" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          ENCRYPTION_KEY_SECRET: ${{ secrets.encryption-key }}
       - name: Terraform Bootstrap
         id: bootstrap
         uses: appvia/appvia-cicd-workflows/.github/actions/terraform-bootstrap@da2bf7ed16cc9778fedff463249466ca88069df5 # main
@@ -433,6 +477,11 @@ jobs:
           fi
       - name: Calculate Plan Checksum
         run: sha256sum tfplan > tfplan.checksum
+      - name: Encrypt Plan Artifacts
+        if: inputs.enable-plan-encryption
+        uses: appvia/appvia-cicd-workflows/.github/actions/terraform-plan-encrypt@feat/terraform-encryption # TODO: pin to SHA once merged
+        with:
+          working-directory: ${{ inputs.working-directory }}
       - name: Upload tfplan
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -698,6 +747,24 @@ jobs:
         with:
           name: tfplan-${{ inputs.environment }}-${{ github.event.pull_request.number }}
         continue-on-error: true
+      - name: Restore Encryption Key
+        if: inputs.enable-plan-encryption
+        shell: bash
+        run: |
+          if [ -n "$ENCRYPTION_KEY_SECRET" ]; then
+            echo "$ENCRYPTION_KEY_SECRET" > /tmp/tfplan-enc-key
+          else
+            EPHEMERAL_KEY="${{ needs.terraform-plan.outputs.encryption-key }}"
+            echo "::add-mask::${EPHEMERAL_KEY}"
+            echo "${EPHEMERAL_KEY}" > /tmp/tfplan-enc-key
+          fi
+        env:
+          ENCRYPTION_KEY_SECRET: ${{ secrets.encryption-key }}
+      - name: Decrypt Plan Artifacts
+        if: inputs.enable-plan-encryption
+        uses: appvia/appvia-cicd-workflows/.github/actions/terraform-plan-decrypt@feat/terraform-encryption # TODO: pin to SHA once merged
+        with:
+          working-directory: ${{ inputs.working-directory }}
       - name: Check Artifact Availability
         run: |
           if [ ! -f tfplan ]; then

--- a/.github/workflows/terraform-plan-and-apply-aws.yml
+++ b/.github/workflows/terraform-plan-and-apply-aws.yml
@@ -19,7 +19,7 @@ on:
         description: "A JSON object of file paths and their base64 encoded contents to be created in the working directory"
         required: false
       encryption-key:
-        description: "Static encryption key for plan artifacts. If not set, an ephemeral key is generated per run."
+        description: "Encryption key for plan artifacts. Required when enable-plan-encryption is true."
         required: false
 
     inputs:
@@ -324,23 +324,11 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tfplan-${{ inputs.environment }}-${{ github.event.pull_request.number }}
-      - name: Restore Encryption Key
-        if: inputs.enable-plan-encryption
-        shell: bash
-        run: |
-          if [ -n "$ENCRYPTION_KEY_SECRET" ]; then
-            echo "$ENCRYPTION_KEY_SECRET" > /tmp/tfplan-enc-key
-          else
-            EPHEMERAL_KEY="${{ needs.terraform-plan.outputs.encryption-key }}"
-            echo "::add-mask::${EPHEMERAL_KEY}"
-            echo "${EPHEMERAL_KEY}" > /tmp/tfplan-enc-key
-          fi
-        env:
-          ENCRYPTION_KEY_SECRET: ${{ secrets.encryption-key }}
       - name: Decrypt Plan Artifacts
         if: inputs.enable-plan-encryption
         uses: appvia/appvia-cicd-workflows/.github/actions/terraform-plan-decrypt@feat/terraform-encryption # TODO: pin to SHA once merged
         with:
+          encryption-key: ${{ secrets.encryption-key }}
           files: tfplan.json
       - name: Generate Infracost Cost Estimate
         run: |
@@ -371,29 +359,11 @@ jobs:
       result-validate: ${{ steps.validate.outcome }}
       result-s3-backend-check: ${{ steps.s3-backend-check.outcome }}
       result-plan: ${{ steps.plan.outcome }}
-      encryption-key: ${{ steps.encryption-key.outputs.key }}
     env:
       TF_LOG: ${{ needs.debug-mode.outputs.tf_log }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - name: Generate Encryption Key
-        id: encryption-key
-        if: inputs.enable-plan-encryption
-        shell: bash
-        run: |
-          if [ -n "$ENCRYPTION_KEY_SECRET" ]; then
-            echo "Using static encryption key from secret"
-            echo "$ENCRYPTION_KEY_SECRET" > /tmp/tfplan-enc-key
-          else
-            echo "Generating ephemeral encryption key"
-            ENCRYPTION_KEY=$(openssl rand -hex 32)
-            echo "::add-mask::${ENCRYPTION_KEY}"
-            echo "${ENCRYPTION_KEY}" > /tmp/tfplan-enc-key
-            echo "key=${ENCRYPTION_KEY}" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          ENCRYPTION_KEY_SECRET: ${{ secrets.encryption-key }}
       - name: Terraform Bootstrap
         id: bootstrap
         uses: appvia/appvia-cicd-workflows/.github/actions/terraform-bootstrap@da2bf7ed16cc9778fedff463249466ca88069df5 # main
@@ -481,6 +451,7 @@ jobs:
         if: inputs.enable-plan-encryption
         uses: appvia/appvia-cicd-workflows/.github/actions/terraform-plan-encrypt@feat/terraform-encryption # TODO: pin to SHA once merged
         with:
+          encryption-key: ${{ secrets.encryption-key }}
           working-directory: ${{ inputs.working-directory }}
       - name: Upload tfplan
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -747,23 +718,11 @@ jobs:
         with:
           name: tfplan-${{ inputs.environment }}-${{ github.event.pull_request.number }}
         continue-on-error: true
-      - name: Restore Encryption Key
-        if: inputs.enable-plan-encryption
-        shell: bash
-        run: |
-          if [ -n "$ENCRYPTION_KEY_SECRET" ]; then
-            echo "$ENCRYPTION_KEY_SECRET" > /tmp/tfplan-enc-key
-          else
-            EPHEMERAL_KEY="${{ needs.terraform-plan.outputs.encryption-key }}"
-            echo "::add-mask::${EPHEMERAL_KEY}"
-            echo "${EPHEMERAL_KEY}" > /tmp/tfplan-enc-key
-          fi
-        env:
-          ENCRYPTION_KEY_SECRET: ${{ secrets.encryption-key }}
       - name: Decrypt Plan Artifacts
         if: inputs.enable-plan-encryption
         uses: appvia/appvia-cicd-workflows/.github/actions/terraform-plan-decrypt@feat/terraform-encryption # TODO: pin to SHA once merged
         with:
+          encryption-key: ${{ secrets.encryption-key }}
           working-directory: ${{ inputs.working-directory }}
       - name: Check Artifact Availability
         run: |

--- a/docs/terraform-plan-and-apply-aws.md
+++ b/docs/terraform-plan-and-apply-aws.md
@@ -63,6 +63,7 @@ jobs:
 - `enable-infracost` - Default: false. Whether to run infracost on the Terraform Plan (requires `infracost-api-key` secret)
 - `enable-checkov` - Default: true. Whether to run Checkov security scanning
 - `enable-commitlint` - Default: true. Whether to run commitlint on the commit message
+- `enable-plan-encryption` - Default: true. Whether to encrypt Terraform plan artifacts at rest. When enabled, the binary plan (`tfplan`) and JSON plan (`tfplan.json`) are encrypted using AES-256-CBC before being uploaded as artifacts. An ephemeral key is generated per workflow run unless a static `encryption-key` secret is provided
 - `enable-terraform-apply` - Default: true. Whether to run terraform apply on merge to main
 - `enable-private-access` - Default: false. Flag to state if terraform requires pulling private modules
 - `organization-name` - Default: "appvia". The name of the GitHub organization
@@ -114,6 +115,7 @@ jobs:
       "my-file.txt": "SGVsbG8gV29ybGQh"
     }
   ```
+- `encryption-key` - Static encryption key for plan artifacts. If not set, an ephemeral key is generated per workflow run and passed between jobs via masked job outputs. To use a static key, generate one with `openssl rand -base64 32` and store it as a repository or organization secret.
 
 **Note:** This template may change over time, so it is recommended that you point to a tagged version rather than the main branch.
 

--- a/docs/terraform-plan-and-apply-aws.md
+++ b/docs/terraform-plan-and-apply-aws.md
@@ -63,7 +63,7 @@ jobs:
 - `enable-infracost` - Default: false. Whether to run infracost on the Terraform Plan (requires `infracost-api-key` secret)
 - `enable-checkov` - Default: true. Whether to run Checkov security scanning
 - `enable-commitlint` - Default: true. Whether to run commitlint on the commit message
-- `enable-plan-encryption` - Default: true. Whether to encrypt Terraform plan artifacts at rest. When enabled, the binary plan (`tfplan`) and JSON plan (`tfplan.json`) are encrypted using AES-256-CBC before being uploaded as artifacts. An ephemeral key is generated per workflow run unless a static `encryption-key` secret is provided
+- `enable-plan-encryption` - Default: true. Whether to encrypt Terraform plan artifacts at rest. When enabled, the binary plan (`tfplan`) and JSON plan (`tfplan.json`) are encrypted using AES-256-CBC before being uploaded as artifacts. Requires the `encryption-key` secret to be set
 - `enable-terraform-apply` - Default: true. Whether to run terraform apply on merge to main
 - `enable-private-access` - Default: false. Flag to state if terraform requires pulling private modules
 - `organization-name` - Default: "appvia". The name of the GitHub organization
@@ -115,7 +115,7 @@ jobs:
       "my-file.txt": "SGVsbG8gV29ybGQh"
     }
   ```
-- `encryption-key` - Static encryption key for plan artifacts. If not set, an ephemeral key is generated per workflow run and passed between jobs via masked job outputs. To use a static key, generate one with `openssl rand -base64 32` and store it as a repository or organization secret.
+- `encryption-key` - Encryption key for plan artifacts. Required when `enable-plan-encryption` is true. Generate with `openssl rand -base64 32` and store as a repository or organization secret.
 
 **Note:** This template may change over time, so it is recommended that you point to a tagged version rather than the main branch.
 


### PR DESCRIPTION
# Terraform Plan Artifact Encryption

## Problem

Terraform plan files (`tfplan`, `tfplan.json`) uploaded as GitHub Actions artifacts are stored unencrypted. These files can contain sensitive data including provider credentials, state values, and output values. Anyone with read access to the repository can download and inspect them.

Additionally, the `terraform-destroy.yml` workflow was uploading plan artifacts without generating checksums and applying without verifying them - this is being updated for consistency.

Additionally, I want to split out the reusable logic, ready to add azure-specific workflows, whilst minimising duplication with existing code.

## Solution

### New composite actions

Two new reusable composite actions that handle encryption and decryption of plan artifacts using `openssl` AES-256-CBC with PBKDF2 key derivation:

- **`.github/actions/terraform-plan-encrypt/action.yml`** — Encrypts specified plan files (default: `tfplan` and `tfplan.json`) using a symmetric key provided via the `encryption-key` input. Produces `.enc` files and removes the plaintext originals. Cleans up the key file after use.

- **`.github/actions/terraform-plan-decrypt/action.yml`** — Decrypts `.enc` files back to their originals using the same key. Removes the encrypted files after decryption. Cleans up the key file after use.

Both actions are platform-agnostic and designed to be reused by future Azure workflows.

### Key management

Encryption uses a static symmetric key stored as a GitHub secret (`encryption-key`). Consuming repositories generate a key with `openssl rand -base64 32` and store it as a repository or organisation secret. The key is passed to the composite actions via the workflow's `secrets` block and is never logged (GitHub automatically masks secrets in workflow logs).

Options for ephemerally generating within the pipeline were looked at, but masking prevented passing between jobs in the way I wanted. Other values (such as id token) don't persist between jobs and aren't suitable.

### Workflow changes

**`terraform-plan-and-apply-aws.yml`:**

- New `encryption-key` secret input
- New `enable-plan-encryption` boolean input (default: `true`)
- Plan job: encrypts `tfplan` and `tfplan.json` after checksum generation, before artifact upload
- Apply job: decrypts artifacts after download, before checksum verification and `terraform apply`
- Infracost job: decrypts `tfplan.json` after download, before cost estimation
- Update PR job: no changes needed (only reads unencrypted `tfplan-simple` and `tfplan-summary`)

**`terraform-destroy.yml`:**

- Same encryption inputs and secret as above
- Fixed missing checksum generation in the plan job (previously absent)
- Fixed missing checksum verification in the apply job (previously absent)
- Fixed missing artifact availability check in the apply job (previously absent)
- Added `continue-on-error: true` on artifact download (consistent with plan-and-apply pattern)

### Checksum + encryption ordering

The SHA256 checksum is computed on the **unencrypted** plan file, preserving the existing integrity verification:

1. Plan job: `sha256sum tfplan > tfplan.checksum` (on plaintext) -> encrypt -> upload
2. Apply job: download -> decrypt -> `sha256sum -c tfplan.checksum` (on decrypted file) -> apply

### What is and isn't encrypted

| File | Encrypted | Reason |
|---|---|---|
| `tfplan` | Yes | Binary plan containing full state values and provider configs |
| `tfplan.json` | Yes | JSON representation with all values including those marked sensitive |
| `tfplan-simple` | No | Resource names and change types only, used for PR comments |
| `tfplan-summary` | No | Single-line summary (e.g. "Plan: 2 to add, 1 to change") |
| `tfplan.stdout` | No | Raw stdout, not consumed by downstream jobs |
| `tfplan.checksum` | No | SHA256 hash, must remain unencrypted for verification |

### Documentation

- `docs/terraform-plan-and-apply-aws.md` updated with new input and secret descriptions
- `.claude/CLAUDE.md` updated with new composite actions table entries and encryption pattern documentation

## Files changed

| File | Change |
|---|---|
| `.github/actions/terraform-plan-encrypt/action.yml` | New |
| `.github/actions/terraform-plan-decrypt/action.yml` | New |
| `.github/workflows/terraform-plan-and-apply-aws.yml` | Modified |
| `.github/workflows/terraform-destroy.yml` | Modified |
| `docs/terraform-plan-and-apply-aws.md` | Modified |
| `.claude/CLAUDE.md` | Modified |

## Testing
Whilst I'm no AWS expert, I bootstrapped enough in my personal account to test a PR and merge into main. This can be seen successfully running in the following action runs:

* https://github.com/appvia/mike-tf-encryption-test/actions/runs/28472676585
* https://github.com/appvia/mike-tf-encryption-test/actions/runs/28472748159

## Backward compatibility

- Encryption is enabled by default (`enable-plan-encryption: true`). Consuming repos that do not provide the `encryption-key` secret must either set it or disable encryption with `enable-plan-encryption: false`.
- The artifact glob pattern `tfplan*` continues to match both encrypted (`.enc`) and unencrypted file variants.
- The `update-pr` job requires no changes as it only reads unencrypted summary files.

## Future work

- Pin composite action references to SHA once merged (currently using branch ref `@feat/terraform-encryption`)
