### PR TITLE
fix(docs): grant pages permission and the github-pages environment to the docs deploy

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -9,6 +9,11 @@ permissions:
   contents: read
   # Required to authenticate the Github API
   id-token: write
+  # Required by actions/configure-pages to read the Pages site, and by
+  # actions/deploy-pages to publish. A reusable workflow that declares its own
+  # permissions block does not inherit the caller's, so omitting this makes the
+  # caller's `pages: write` ineffective.
+  pages: write
   # Required to write PR comments with the validation results
   pull-requests: write
 
@@ -19,6 +24,11 @@ jobs:
   deploy:
     name: Deploy Documentation
     runs-on: ubuntu-latest
+    # actions/deploy-pages publishes through the github-pages environment, so
+    # the job has to declare it.
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
Documentation deploys have been failing since consumers moved onto this shared workflow. [`appvia-docs-template` run 30283784051](https://github.com/appvia/appvia-docs-template/actions/runs/30283784051) fails at **Setup Pages**:

```
Get Pages site failed. Please verify that the repository has Pages enabled and
configured to build using GitHub Actions...
Error: Resource not accessible by integration
HttpError: 403 on GET /repos/{owner}/{repo}/pages
```

## Cause

`actions/configure-pages` calls `GET /repos/{owner}/{repo}/pages`, which needs the **`pages`** permission. This workflow's `permissions` block grants `contents`, `id-token` and `pull-requests`, but not `pages`.

**The caller granting it is not enough**, which is the part worth knowing. A reusable workflow that declares its own `permissions` block does not inherit the caller's; the effective set is the intersection of the two. `appvia-docs-template` does set `pages: write` at workflow level, and it has had no effect since the move to this shared workflow, because `pages` was absent on this side.

That also explains a confusing bisect. The failure looks like it began at [`14f17e1`](https://github.com/appvia/appvia-docs-template/commit/14f17e1f3afd0f56aaeabf6ed2201bc11ce3d130) ("fix: resolved the permissions"), but that commit is innocent. The regression is the earlier move to shared workflows, which still carried `paths:` filters so Deploy never ran. `14f17e1` was simply the first commit where Deploy actually executed under the new setup.

Ruled out: Pages is enabled on the consumer (`build_type: workflow`, custom domain `docs-template.solutions.appvia.io`, valid certificate), so this is not a repository setting.

## Changes

1. **`pages: write`** added to the permissions block.
2. **`environment: github-pages`** added to the deploy job. `actions/deploy-pages` publishes through that environment, so the job has to declare it. The self-contained workflow this replaced had it, and it was dropped in the move.

Being straight about the evidence: defect 1 is confirmed by the 403 in the run log. Defect 2 is the documented requirement for `actions/deploy-pages`, not an observed failure, because the run never gets that far. It would surface immediately after fixing 1.

I checked that the `github-pages` environment already exists on the consumer repo with only a `branch_policy` rule, so this introduces no manual approval gate.

## Verification

The YAML parses. I have not proved the fix end to end: the environment's branch policy restricts deployments to `main`, so a `workflow_dispatch` from a test branch will not exercise it. The honest test is to merge this and re-run the failed deploy on `appvia-docs-template`. Happy to do that and report back.

## Not changed, but worth a look

`pull-requests: write` is granted here and commented as "required to write PR comments with the validation results". This is the deploy workflow, which does not comment on pull requests. It looks like a copy from `documentation-validation.yml` and could be dropped as unnecessary write scope. Left alone to keep this PR to the fix.